### PR TITLE
Proposed path fixes on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 uni-sync-backup.json
+/.idea

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,9 @@ ExecStart=${BIN_PREFIX}/uni-sync ${CONF_PREFIX}/uni-sync.json
 WantedBy=multi-user.target
 SERVICE
     sudo mv -f uni-sync.service /etc/systemd/system
-    sudo mv -f uni-sync ${BIN_PREFIX}
+    sudo mv -f uni-sync ${BIN_PREFIX} 
+
+    mkdir -p ${CONF_PREFIX}
     sudo cp -n uni-sync.json ${CONF_PREFIX}
     sudo chown $USER ${CONF_PREFIX}/uni-sync.json
     sudo systemctl enable uni-sync

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+BIN_PREFIX=/usr/local/sbin
+CONF_PREFIX=/etc/uni-sync
+
 # Check for Rust Function
 check_rust() {
     echo '🦀 Checking for Rust'
@@ -37,14 +40,14 @@ install_app() {
 [Unit]
 Description=Uni-Sync service
 [Service]
-ExecStart=/usr/sbin/uni-sync
+ExecStart=${BIN_PREFIX}/uni-sync ${CONF_PREFIX}/uni-sync.json
 [Install]
 WantedBy=multi-user.target
 SERVICE
     sudo mv -f uni-sync.service /etc/systemd/system
-    sudo mv -f uni-sync /usr/sbin
-    sudo cp -n uni-sync.json /usr/sbin
-    sudo chown $USER /usr/sbin/uni-sync.json
+    sudo mv -f uni-sync ${BIN_PREFIX}
+    sudo cp -n uni-sync.json ${CONF_PREFIX}
+    sudo chown $USER ${CONF_PREFIX}/uni-sync.json
     sudo systemctl enable uni-sync
     sudo systemctl restart uni-sync
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,29 @@
 use std::env;
+use std::path::PathBuf;
 
 mod devices;
 
 fn main() -> Result<(), std::io::Error> {
- 
     let mut configs = devices::Configs {
         configs: vec![]
     };
 
-    let mut config_path = env::current_exe()?;
-    config_path.pop();
-    config_path.push("uni-sync.json");
+    let args: Vec<String> = env::args().collect();
+    let mut config_path: PathBuf = env::current_exe()?;
+
+    if args.len() == 2 {
+        config_path.clear();
+        config_path.push(&args[1])
+    } else {
+        config_path.pop();
+        config_path.push("uni-sync.json");
+    }
 
     if !config_path.exists() {
+        println!("Config path {:?} does not exist. Generating default configuration.", config_path);
         std::fs::write(&config_path, serde_json::to_string_pretty(&configs).unwrap())?;
+    } else {
+        println!("Loading configuration {:?}", config_path)
     }
 
     let config_content = std::fs::read_to_string(&config_path).unwrap();


### PR DESCRIPTION
This PR includes two proposed changes: 

1. Change the install location from /usr/sbin to /usr/local/sbin. By convention, /usr/local is the preferred destination for non-system-managed binaries.
2. Change the default location of uni-sync.json from the installation path to /etc/uni-sync/uni-sync.json instead. To support this change, uni-sync now accepts an optional path on the command line. 