### PR TITLE
Extend device ID with sys device path

### DIFF
--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -50,7 +50,12 @@ pub fn run(mut existing_configs: Configs) -> Configs {
                     continue; 
                 }
             };
-            let device_id: String = format!("VID:{}/PID:{}/SN:{}", hiddevice.vendor_id().to_string(), hiddevice.product_id().to_string(), serial_number.to_string());
+
+            let path: &str = match hiddevice.path() {
+                p => p.to_str().unwrap_or("unknown"),
+            };
+
+            let device_id: String = format!("VID:{}/PID:{}/SN:{}/PATH:{}", hiddevice.vendor_id().to_string(), hiddevice.product_id().to_string(), serial_number.to_string(), path.to_string());
             let hid: HidDevice = match api.open(hiddevice.vendor_id(), hiddevice.product_id()) {
                 Ok(hid) => hid,
                 Err(_) => {


### PR DESCRIPTION
I have two controllers, which both get detected, but LianLi uses the same serial, so uni-sync can't differentiate settings in the config. This patch extends the deviceId to include syspath, which fixes this problem.

![image](https://github.com/user-attachments/assets/41d9f628-d5db-4f51-b254-21822c4ba3e7)
